### PR TITLE
pass nproc to pool

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - toml
   - pandas
   - xdem
+  - rioxarray
   - opencv
   - oggm
   - oggm-deps

--- a/ragmac_xdem/dem_postprocessing.py
+++ b/ragmac_xdem/dem_postprocessing.py
@@ -650,7 +650,7 @@ def merge_and_calculate_ddems(groups, validation_dates, ref_dem, mode, outdir, o
 
             # Then calculate linear fit
             print("\n### Run linear fit ###")
-            results = temporal.linreg_run_parallel(X_train, valid_data, method="TheilSen")
+            results = temporal.linreg_run_parallel(X_train, valid_data, cpu_count=nproc, method="TheilSen")
             results_stack = temporal.linreg_reshape_parallel_results(results, ma_stack, valid_mask_2D)
 
             slope = results_stack[0]
@@ -662,7 +662,7 @@ def merge_and_calculate_ddems(groups, validation_dates, ref_dem, mode, outdir, o
 
             # Not needed for now
             # print('\n### Compute residuals ###')
-            # prediction = temporal.linreg_predict_parallel(slope,X_train,intercept)
+            # prediction = temporal.linreg_predict_parallel(slope,X_train,intercept, cpu_count=nproc)
             # residuals  = ma_stack - prediction
             # residuals[:,valid_mask_2D]  = residuals[:,valid_mask_2D]
 

--- a/ragmac_xdem/temporal.py
+++ b/ragmac_xdem/temporal.py
@@ -398,8 +398,7 @@ def linreg_predict_parallel(slope, X, intercept, cpu_count=None):
     if not cpu_count:
         cpu_count = mp.cpu_count() - 1
     pool = mp.Pool(processes=cpu_count)
-    args = [(slope, x, intercept) for x in X]
-    results = pool.map(linreg_predict, tqdm(args))
+    results = pool.map(linreg_predict, tqdm([(slope, x, intercept) for x in X]))
     return np.ma.array(results)
 
 
@@ -417,8 +416,7 @@ def linreg_run_parallel(X_train, ma_stack, cpu_count=None, method="TheilSen"):
     if not cpu_count:
         cpu_count = mp.cpu_count() - 1
     pool = mp.Pool(processes=cpu_count)
-    args = [(X_train, ma_stack[:, i], method) for i in range(ma_stack.shape[1])]
-    results = pool.map(linreg_run, tqdm(args))
+    results = pool.map(linreg_run, tqdm([(X_train, ma_stack[:, i], method) for i in range(ma_stack.shape[1])]))
     return np.array(results)
 
 
@@ -507,8 +505,7 @@ def GPR_run_parallel(X_train, ma_stack, X, kernel, cpu_count=None):
     if not cpu_count:
         cpu_count = mp.cpu_count() - 1
     pool = mp.Pool(processes=cpu_count)
-    args = [(X_train, ma_stack[:, i], X, kernel) for i in range(ma_stack.shape[1])]
-    results = pool.map(GPR_run, args)
+    results = pool.map(GPR_run, tqdm([(X_train, ma_stack[:, i], X, kernel) for i in range(ma_stack.shape[1])]))
     return np.array(results)
 
 

--- a/ragmac_xdem/temporal.py
+++ b/ragmac_xdem/temporal.py
@@ -394,8 +394,10 @@ def linreg_predict(args):
     return prediction
 
 
-def linreg_predict_parallel(slope, X, intercept):
-    pool = mp.Pool(processes=psutil.cpu_count(logical=True))
+def linreg_predict_parallel(slope, X, intercept, cpu_count=None):
+    if not cpu_count:
+        cpu_count = mp.cpu_count() - 1
+    pool = mp.Pool(processes=cpu_count)
     args = [(slope, x, intercept) for x in X]
     results = pool.map(linreg_predict, tqdm(args))
     return np.ma.array(results)
@@ -411,8 +413,10 @@ def linreg_reshape_parallel_results(results, ma_stack, valid_mask_2D):
     return results_stack
 
 
-def linreg_run_parallel(X_train, ma_stack, method="Linear"):
-    pool = mp.Pool(processes=psutil.cpu_count(logical=True))
+def linreg_run_parallel(X_train, ma_stack, cpu_count=None, method="Linear"):
+    if not cpu_count:
+        cpu_count = mp.cpu_count() - 1
+    pool = mp.Pool(processes=cpu_count)
     args = [(X_train, ma_stack[:, i], method) for i in range(ma_stack.shape[1])]
     results = pool.map(linreg_run, tqdm(args))
     return np.array(results)
@@ -499,8 +503,10 @@ def GPR_run(args):
     return prediction
 
 
-def GPR_run_parallel(X_train, ma_stack, X, kernel):
-    pool = mp.Pool(processes=psutil.cpu_count(logical=True))
+def GPR_run_parallel(X_train, ma_stack, X, kernel, cpu_count=None):
+    if not cpu_count:
+        cpu_count = mp.cpu_count() - 1
+    pool = mp.Pool(processes=cpu_count)
     args = [(X_train, ma_stack[:, i], X, kernel) for i in range(ma_stack.shape[1])]
     results = pool.map(GPR_run, args)
     return np.array(results)

--- a/ragmac_xdem/temporal.py
+++ b/ragmac_xdem/temporal.py
@@ -383,7 +383,7 @@ def linreg_run(args):
     X_train, y_train_masked_array, method = args
 
     X_train, y_train = remove_nan_from_training_data(X_train, y_train_masked_array)
-    slope, intercept = linreg_fit(X_train, y_train, method="Linear")
+    slope, intercept = linreg_fit(X_train, y_train, method=method)
 
     return slope, intercept
 
@@ -413,7 +413,7 @@ def linreg_reshape_parallel_results(results, ma_stack, valid_mask_2D):
     return results_stack
 
 
-def linreg_run_parallel(X_train, ma_stack, cpu_count=None, method="Linear"):
+def linreg_run_parallel(X_train, ma_stack, cpu_count=None, method="TheilSen"):
     if not cpu_count:
         cpu_count = mp.cpu_count() - 1
     pool = mp.Pool(processes=cpu_count)


### PR DESCRIPTION
Pass `nproc` from `main_experiment2.py` down to `linreg_run_parallel()`

Avoid additional dependency by using `mp.cpu_count()` instead of `psutil` to get cpu count.

Add `rioxarray` to `environment.yml`

Resolves #27