### PR TITLE
Add TimeSeries3 mode with dask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,10 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
+dask-worker-space/
+dev/
+src/
+nv/
 build/
 develop-eggs/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,14 @@ __pycache__/
 
 # C extensions
 *.so
+# Dask
+dask-worker-space/
 
 # Distribution / packaging
 .Python
-dask-worker-space/
 dev/
 src/
-nv/
+env/
 build/
 develop-eggs/
 dist/

--- a/ragmac_xdem/dem_postprocessing.py
+++ b/ragmac_xdem/dem_postprocessing.py
@@ -767,8 +767,9 @@ def merge_and_calculate_ddems(groups, validation_dates, ref_dem, mode, outdir, o
             
             # need to convert timestamps back to yr-1 if using matplotlib.dates.date2num
             # these same conversions are used in temporal.ma_linreg()
-            slope = results['slope'].values
-            slope *= 365.25
+            results['slope'] = results['slope'] * 365.25
+            
+            slope = np.ma.masked_invalid(results['slope'].values)
 
             # Finally, calculate total elevation change
             date1 = validation_dates[k1]

--- a/ragmac_xdem/dem_postprocessing.py
+++ b/ragmac_xdem/dem_postprocessing.py
@@ -20,6 +20,8 @@ import pandas as pd
 import xdem
 from skimage.morphology import disk
 from tqdm import tqdm
+import matplotlib
+import xarray as xr
 
 from ragmac_xdem import io, temporal, utils
 
@@ -613,7 +615,7 @@ def merge_and_calculate_ddems(groups, validation_dates, ref_dem, mode, outdir, o
                 ddems[pair_id] = mosaics[date2] - mosaics[date1]
 
     elif mode == "shean":
-
+        
         for count, pair in enumerate(pair_indexes):
             k1, k2 = pair
             dems_list = groups[count]
@@ -651,42 +653,46 @@ def merge_and_calculate_ddems(groups, validation_dates, ref_dem, mode, outdir, o
             dyear = (date2_dt - date1_dt).total_seconds() / (3600 * 24 * 365.25)
             ddems[pair_id] = dyear * slope
 
-    elif mode == "knuth":
-
+    elif mode == "TimeSeries2":
+        
         for count, pair in enumerate(pair_indexes):
             k1, k2 = pair
-            date1 = validation_dates[k1]
-            date2 = validation_dates[k2]
+            dems_list = groups[count]
             pair_id = pair_ids[count]
             print(f"\nProcessing pair {pair_id}")
 
             # First stack all DEMs
             start = datetime.now()
-            
-            dems_list = groups[count]
             dem_dates = utils.get_dems_date(dems_list)
-
             ds = io.xr_stack_geotifs(dems_list, dem_dates, ref_dem.filename)
-
             ma_stack = np.ma.masked_invalid(ds["band1"].values)
 
             print("\n### Prepare training data ###")
-            X_train = np.ma.array([utils.date_time_to_decyear(i) for i in dem_dates]).data
-            valid_data, valid_mask_2D = temporal.mask_low_count_pixels(ma_stack, n_thresh=5)
+            ## TODO: Determine which time conversion to use as this slightly changes the result.
+#             X_train = np.ma.array([utils.date_time_to_decyear(i) for i in dem_dates]).data
+            X_train = np.array(matplotlib.dates.date2num(dem_dates))
+    
+            n_thresh = 5
+            print('Excluding pixels with count <',n_thresh)
+            valid_data, valid_mask_2D = temporal.mask_low_count_pixels(ma_stack, n_thresh=n_thresh)
 
             # Then calculate linear fit
             print("\n### Run linear fit ###")
             results = temporal.linreg_run_parallel(X_train, valid_data, cpu_count=nproc, method="TheilSen")
+            
             results_stack = temporal.linreg_reshape_parallel_results(results, ma_stack, valid_mask_2D)
 
             slope = results_stack[0]
-            intercept = results_stack[1]
+            ## Only do this if X_train was generated with matplotlib.dates.date2num. Same procedure as in ma_linreg
+            slope *= 365.25
+
 
             now = datetime.now()
             dt = now - start
             print("Elapsed time:", str(dt).split(".")[0])
 
             # Not needed for now
+            # intercept = results_stack[1]
             # print('\n### Compute residuals ###')
             # prediction = temporal.linreg_predict_parallel(slope,X_train,intercept, cpu_count=nproc)
             # residuals  = ma_stack - prediction
@@ -704,13 +710,76 @@ def merge_and_calculate_ddems(groups, validation_dates, ref_dem, mode, outdir, o
             # print('Elapsed time:', str(dt).split(".")[0])
 
             # Finally, calculate total elevation change
+            date1 = validation_dates[k1]
+            date2 = validation_dates[k2]
+            date1_dt = datetime.strptime(date1, "%Y-%m-%d")
+            date2_dt = datetime.strptime(date2, "%Y-%m-%d")
+            dyear = (date2_dt - date1_dt).total_seconds() / (3600 * 24 * 365.25)
+            ddems[pair_id] = dyear * slope
+            
+    elif mode == "TimeSeries3":
+
+        for count, pair in enumerate(pair_indexes):
+            k1, k2 = pair
+            dems_list = groups[count]
+            pair_id = pair_ids[count]
+            print(f"\nProcessing pair {pair_id}")
+            
+            dems_list = groups[count]
+            dem_dates = utils.get_dems_date(dems_list)
+            
+            time_stamps = np.array(matplotlib.dates.date2num(dem_dates))
+#             time_stamps = np.array([utils.date_time_to_decyear(i) for i in dem_dates])
+
+            ds = io.xr_stack_geotifs(dems_list, dem_dates, ref_dem.filename)
+            
+            # Find optimal chunking scheme
+            
+            # Use full dim length in time but chunk x y into something sensible to speed up processing (WIP)
+            t = len(ds.time)
+            x = len(ds.x)
+            y = len(ds.y)
+            print('\ndata dims: x, y, time')
+            print('data shape:', x,y,t)
+            
+            x = utils.roundup(np.sqrt(len(ds.x))*2)
+            y = utils.roundup(np.sqrt(len(ds.y))*2)
+            print('chunk shape:', x,y,t)
+            
+            # TODO pass down client object to print address here instead of earlier.
+            print('\nCheck dask dashboard to monitor progress. See stdout above for address to dashboard.')
+
+            ds = ds.chunk({"time":t, "x":x, "y":y})
+            
+            n_thresh = 5
+            print('Excluding pixels with count <',n_thresh)
+            results = temporal.dask_apply_linreg(ds['band1'],
+                                                 'time', 
+                                                 kwargs={'times':time_stamps,
+                                                         'n_thresh':n_thresh})
+            
+            start = datetime.now()
+            results = xr.Dataset({'slope':results[0],
+                                  'intercept':results[1]}).compute()
+            now = datetime.now()
+            dt = now - start
+            print("Elapsed dask compute time:", str(dt).split(".")[0])
+            
+            # need to convert timestamps back to yr-1 if using matplotlib.dates.date2num
+            # these same conversions are used in temporal.ma_linreg()
+            slope = results['slope'].values
+            slope *= 365.25
+
+            # Finally, calculate total elevation change
+            date1 = validation_dates[k1]
+            date2 = validation_dates[k2]
             date1_dt = datetime.strptime(date1, "%Y-%m-%d")
             date2_dt = datetime.strptime(date2, "%Y-%m-%d")
             dyear = (date2_dt - date1_dt).total_seconds() / (3600 * 24 * 365.25)
             ddems[pair_id] = dyear * slope
 
     else:
-        raise NotImplementedError("`mode` must be either of 'median', 'shean' or 'knuth'")
+        raise NotImplementedError("`mode` must be either of 'median', 'shean', 'TimeSeries2, or TimeSeries3'")
 
     # Convert masked arrays to gu.Raster
     for key in list(ddems.keys()):

--- a/ragmac_xdem/io.py
+++ b/ragmac_xdem/io.py
@@ -8,9 +8,34 @@ import rioxarray
 import xarray as xr
 from rasterio.enums import Resampling
 
+from dask.distributed import Client, LocalCluster
+import logging
+
 """
 @author: friedrichknuth
 """
+
+def dask_start_cluster(nproc, threads=1, ip_addres=None):
+    """
+    Starts a dask cluster. Can provide a custom IP or URL to view the progress dashboard. 
+    This may be necessary if working on a remote machine.
+    """
+    cluster = LocalCluster(n_workers=nproc,
+                       threads_per_worker=threads,
+                       silence_logs=logging.ERROR)
+
+    client = Client(cluster)
+    
+    if ip_addres:
+        port = str(cluster.dashboard_link.split(':')[-1])
+        url = ":".join([ip_addres,port])
+        print('\n'+'Dask dashboard at:',url)
+    else:
+        print('\n'+'Dask dashboard at:',cluster.dashboard_link)
+    
+    print('Workers:', nproc)
+    print('Threads per worker:', threads, '\n')
+    return client
 
 
 def stack_geotif_arrays(geotif_files_list):
@@ -131,7 +156,7 @@ def xr_stack_geotifs(geotif_files_list, datetimes_list, reference_geotif_file, r
         if save_to_nc:
             out_fn = str(pathlib.Path(file_name).with_suffix("")) + ".nc"
             src.to_netcdf(out_fn)
-            out_dir = str(pathlib.Path(dems_list[i]).parents[0])
+            out_dir = str(pathlib.Path(geotif_files_list[index]).parents[0])
 
         datasets.append(src)
 

--- a/ragmac_xdem/main.py
+++ b/ragmac_xdem/main.py
@@ -74,9 +74,13 @@ def main(case: dict, mode: str, run_name: str, sat_type: str = "ASTER", nproc: i
     elif mode == "TimeSeries2":
         selection_opts = {"mode": "subperiod", "dt": 365}
         downsampling = 1
-        merge_opts = {"mode": "knuth"}
+        merge_opts = {"mode": "TimeSeries2"}
+    elif mode == "TimeSeries3":
+        selection_opts = {"mode": "subperiod", "dt": 365}
+        downsampling = 1
+        merge_opts = {"mode": "TimeSeries3"}
     else:
-        raise ValueError("`mode` must be either of 'median', 'shean' or knuth'")
+        raise ValueError("`mode` must be either of 'median', 'shean', TimeSeries2 or TimeSeries3'")
 
     # Get run parameters
     run = runs[run_name]

--- a/ragmac_xdem/temporal.py
+++ b/ragmac_xdem/temporal.py
@@ -519,14 +519,14 @@ def GPR_reshape_parallel_results(results, ma_stack, valid_mask_2D):
     results_stack = np.ma.stack(results_stack)
     return results_stack
 
-def dask_linreg(chunk, times = None, n_thresh = 5):
+def dask_linreg(DataArray, times = None, n_thresh = 5):
     #TODO vectorize with numba
-    mask = ~np.isnan(chunk)
+    mask = ~np.isnan(DataArray)
     if np.sum(mask) < n_thresh:
         return np.nan, np.nan
 #     m = linear_model.LinearRegression()
     m = linear_model.TheilSenRegressor()
-    m.fit(times[mask].reshape(-1,1), chunk[mask])
+    m.fit(times[mask].reshape(-1,1), DataArray[mask])
     return m.coef_[0], m.intercept_
 
 def dask_apply_linreg(DataArray, dim, kwargs=None):

--- a/ragmac_xdem/utils.py
+++ b/ragmac_xdem/utils.py
@@ -298,13 +298,16 @@ def get_start_end_dates(groups, merge_mode, validation_dates):
             start_date[pair_id] = np.min(get_dems_date(groups[k1]))
             end_date[pair_id] = np.max(get_dems_date(groups[k2]))
 
-    elif (merge_mode == "shean") or (merge_mode == "knuth"):
+    elif (merge_mode == "shean") or (merge_mode == "TimeSeries2") or (merge_mode == "TimeSeries3"):
 
         for count, pair in enumerate(pair_indexes):
             k1, k2 = pair
             pair_id = pair_ids[count]
             start_date[pair_id] = np.min(get_dems_date(groups[k1]))
             end_date[pair_id] = np.max(get_dems_date(groups[k1]))
+            
+    else:
+        raise ValueError("`merge_mode` must be either of 'median', 'shean', TimeSeries2 or TimeSeries3'")
 
     return start_date, end_date
 
@@ -406,3 +409,6 @@ def xr_extract_ma_arrays_at_coords(da, x_coords, y_coords):
         ma_arrays.append(np.ma.masked_invalid(sub.values))
     ma_stack = np.ma.stack(ma_arrays, axis=1)
     return ma_stack
+
+def roundup(x,level=10):
+    return int(np.ceil(x / level)) * level

--- a/scripts/main_experiment1.py
+++ b/scripts/main_experiment1.py
@@ -8,7 +8,7 @@ import argparse
 import multiprocessing as mp
 import traceback
 
-from ragmac_xdem import main
+from ragmac_xdem import main, io
 
 if __name__ == "__main__":
 
@@ -67,7 +67,14 @@ if __name__ == "__main__":
 
     if args.mode is not None:
         all_modes = [args.mode]
-
+        
+    if args.mode == "TimeSeries3":
+        # Need to launch cluster in main script
+        from ragmac_xdem import temporal
+        # TODO add ip_address as an input option.
+        ip_addres=None
+        client = io.dask_start_cluster(args.nproc, ip_addres=ip_addres)
+        
     nruns = len(all_cases) * len(all_modes)
     print(f"## Total of {nruns} runs to be processed ##")
 

--- a/scripts/main_experiment2.py
+++ b/scripts/main_experiment2.py
@@ -8,7 +8,7 @@ import argparse
 import multiprocessing as mp
 import traceback
 
-from ragmac_xdem import main
+from ragmac_xdem import main, io
 
 if __name__ == "__main__":
 
@@ -70,6 +70,13 @@ if __name__ == "__main__":
 
     if args.run is not None:
         all_runs = [args.run]
+        
+    if args.mode == "TimeSeries3":
+        # Need to launch cluster in main script
+        from ragmac_xdem import temporal
+        # TODO add ip_address as an input option.
+        ip_addres=None
+        client = io.dask_start_cluster(args.nproc, ip_addres=ip_addres)
 
     nruns = len(all_cases) * len(all_modes) * len(all_runs)
     print(f"## Total of {nruns} runs to be processed ##")


### PR DESCRIPTION
- Adds option to run TheilSen regression using dask delayed arrays.
- Provides out-of-memory processing on large stacks
- Renames mode `knuth` to `TimeSeries2`.
- Does not impact other processing modes
- Future improvements
  - optimize chunking scheme for faster processing
  - add numba support for faster vectorized processing
  