### PR TITLE
Dem clipping to conserve memory

### DIFF
--- a/ragmac_xdem/dem_postprocessing.py
+++ b/ragmac_xdem/dem_postprocessing.py
@@ -313,7 +313,8 @@ def spatial_filter_ref_iter(
 
 def postprocessing_single(
     dem_path: str,
-    ref_dem: xdem.DEM,
+    #ref_dem: xdem.DEM,
+    ref_dem: str,
     roi_outlines: gu.Vector,
     all_outlines: gu.Vector,
     out_dem_path: str,
@@ -342,8 +343,18 @@ def postprocessing_single(
     :returns: a tuple containing - basename of coregistered DEM, [count of obs, median and NMAD over stable terrain, coverage over roi] before coreg, [same stats] after coreg
     """
     # Load DEM and reproject to ref grid
+    
+    ref_dem = xdem.DEM(ref_dem)
     dem = xdem.DEM(dem_path)
+    common_bounds = gu.projtools.merge_bounds([ref_dem.bounds,dem.bounds],merging_algorithm='intersection')
+    common_bounds = {'left':common_bounds[0],
+                    'bottom':common_bounds[1],
+                    'right':common_bounds[2],
+                    'top':common_bounds[3]}
+    ref_dem = ref_dem.reproject(dst_res=ref_dem.res,dst_bounds=common_bounds,resampling='bilinear')
     dem = dem.reproject(ref_dem, resampling="bilinear")
+
+    
 
     # Create masks
     roi_mask = roi_outlines.create_mask(dem)

--- a/ragmac_xdem/dem_postprocessing.py
+++ b/ragmac_xdem/dem_postprocessing.py
@@ -140,6 +140,9 @@ def calculate_init_stats_parallel(
 
     def _stats_wrapper(dem_path):
         """Calculate stats of a DEM in one thread."""
+        # this try-except block catches error that arise when the source DEM is at the edge of aoi
+        # an example error is plotted in PR#59 
+        # https://github.com/adehecq/ragmac_xdem/pull/59
         try:
             outputs = calculate_init_stats_single(dem_path, ref_dem, roi_outlines, all_outlines)
         except ValueError as e:

--- a/ragmac_xdem/dem_postprocessing.py
+++ b/ragmac_xdem/dem_postprocessing.py
@@ -746,16 +746,13 @@ def merge_and_calculate_ddems(groups, validation_dates, ref_dem, mode, outdir, o
             
             dems_list = groups[count]
             dem_dates = utils.get_dems_date(dems_list)
-            print(f"Number of DEMs found {len(dems_list)}") 
+             
             time_stamps = np.array(matplotlib.dates.date2num(dem_dates))
 #             time_stamps = np.array([utils.date_time_to_decyear(i) for i in dem_dates])
             print("Starting to stack dems")
-            from datetime import datetime
-            print('\n%s' % datetime.now())
-            print('%s UTC\n' % datetime.utcnow())
+            
             ds = io.xr_stack_geotifs(dems_list, dem_dates, ref_dem.filename)
-            print('\n%s' % datetime.now())
-            print('%s UTC\n' % datetime.utcnow())
+
             # Find optimal chunking scheme
             
             # Use full dim length in time but chunk x y into something sensible to speed up processing (WIP)

--- a/ragmac_xdem/dem_postprocessing.py
+++ b/ragmac_xdem/dem_postprocessing.py
@@ -414,7 +414,7 @@ def postprocessing_single(
 
     # Save coregistered DEM
     # project to reference DEM grid for stacking and hole filling later
-    dem_coreg.reproject(xdem.DEM(ref_dem_path),resampling='bilinear').save(out_dem_path,tiled=True)
+    dem_coreg.reproject(xdem.DEM(ref_dem_path,load_data=False),resampling='bilinear').save(out_dem_path,tiled=True)
     #dem_coreg.save(out_dem_path, tiled=True)
 
     return (

--- a/ragmac_xdem/main.py
+++ b/ragmac_xdem/main.py
@@ -111,7 +111,7 @@ def main(case: dict, mode: str, run_name: str, sat_type: str = "ASTER", nproc: i
     print("\n### Coregister DEMs ###")
     stats, groups_coreg = pproc.postprocessing_all(
         groups,
-        ref_dem,
+        ref_dem.filename,
         roi_outlines,
         all_outlines,
         coreg_dir,

--- a/ragmac_xdem/main.py
+++ b/ragmac_xdem/main.py
@@ -96,7 +96,7 @@ def main(case: dict, mode: str, run_name: str, sat_type: str = "ASTER", nproc: i
     print("\n### Calculate initial statistics ###")
     stats_file = os.path.join(process_dir, "init_stats.csv")
     init_stats = pproc.calculate_init_stats_parallel(
-        dems_files, ref_dem, roi_outlines, all_outlines, stats_file, nthreads=nproc, overwrite=overwrite
+        dems_files, ref_dem.filename, roi_outlines, all_outlines, stats_file, nthreads=nproc, overwrite=overwrite
     )
     print(f"Statistics file saved to {stats_file}")
 

--- a/ragmac_xdem/utils.py
+++ b/ragmac_xdem/utils.py
@@ -221,7 +221,11 @@ def dems_selection(
     :returns: List containing lists of DEM paths for each validation date. Same length as validation dates, or as the number of possible pair combinations for mode 'subperiod'.
     """
     # Remove DEMs with less than 1000 valid points, which may fail during coreg
-    dem_path_list = dem_path_list[init_stats["nstable_orig"] > 1e3]
+    # modified to avoid conflict if init stats failed for edgecase DEM
+     
+    mask = init_stats["nstable_orig"] > 1e3
+    dem_path_list = init_stats[mask]["dem_path"].values
+    #dem_path_list = dem_path_list[init_stats["nstable_orig"] > 1e3]
 
     if mode is None:
         print(f"Found {len(dem_path_list)} DEMs")
@@ -247,6 +251,7 @@ def dems_selection(
                 matching_dates = np.where((date1 <= dems_dates) & (dems_dates <= date2) & np.isin(dems_months, months))[
                     0
                 ]
+                
                 output_list.append(dem_path_list[matching_dates])
                 print(f"For period {validation_dates[k1]} - {validation_dates[k2]} found {len(matching_dates)} DEMs")
             return output_list


### PR DESCRIPTION
This PR should be able to clip reference DEM to intersection with source DEM and then do stats calculation and co-reg in parallel without filling up memory. 
In addition, it fixes two more bugs: 
* duing init_stats calculation, we compute masks from RGI polygons, but if DEM is at the corner of extent of polygons, we get a ValueError as in the screenshot. So added a try/except block to skip such DEMs in dem_postprocessing.py calculate_init_stats_parallel function.
![image](https://user-images.githubusercontent.com/29011666/156079048-82d03e7e-69df-4550-8fa3-be37bdb54456.png)
* Due to above change, I modified utils.py dem_selection function to avoid the length mismatch between init_stats.csv which is already missing some edge case DEMs and dem_path_list. Related to this, dem_path_list should be a numpy array, not a list, if we want to [perform integer indexing](https://github.com/adehecq/ragmac_xdem/blob/6df7f913d7503166f018e08a6d172fe271775edd/ragmac_xdem/utils.py#L255) by using matching_dates array as explained [here](https://stackoverflow.com/questions/50997928/typeerror-only-integer-scalar-arrays-can-be-converted-to-a-scalar-index-with-1d).
