### PR TITLE
Change default chunking scheme to 'auto'

### DIFF
--- a/ragmac_xdem/io.py
+++ b/ragmac_xdem/io.py
@@ -59,7 +59,7 @@ def stack_geotif_arrays(geotif_files_list):
     return ma_stack
 
 
-def xr_read_geotif(geotif_file_path, chunks=1000, masked=True):
+def xr_read_geotif(geotif_file_path, chunks='auto', masked=True):
     """
     Reads in single or multi-band GeoTIFF as dask array.
 


### PR DESCRIPTION
Allow dask to determine default chunking scheme when loading single and later stacking DEMs. Defaults to chunks by time stamp and full x, y extent of the entire stack.

Notes
- The chunking scheme can be changed after the stack is created, e.g. to be more efficient when distributing the temporal regression. [See here. ](https://github.com/adehecq/ragmac_xdem/blob/master/ragmac_xdem/dem_postprocessing.py#L745)
- For co-reg, the numpy array from the reference DEM that corresponds a given DEM, can be extracted with something like:

```
src = rasterio.open(dems_list[0])
bounds = src.bounds

dem_time_stamp = ds.time.values[0]
ref_dem_time_stamp = ds.time.values[-1]

dem_array = ds['band1'].loc[dem_time_stamp].sel(x=slice(bounds[0],
                                                        bounds[2]),
                                                y=slice(bounds[3],
                                                        bounds[1])).values

ref_dem_array = ds['band1'].loc[ref_dem_time_stamp].sel(x=slice(bounds[0],
                                                                bounds[2]),
                                                        y=slice(bounds[3],
                                                                bounds[1])).values
```

Example assumes the first DEM is being co-registered with the last DEM in the stack, which is the reference DEM. The reference DEM needs to be included in the `dems_list`, when passed to `ds = io.xr_stack_geotifs(dems_list, dem_dates, ref_dem.filename)`. The `dem_dates` list of time stamps should also include the time stamp for the reference DEM, in this case as the last item.