### PR TITLE
make qc routines optional

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
   - oggm-deps
   - dask
   - distributed
+  - zarr
   - jupyterlab
   - pip
   # dev requirements

--- a/ragmac_xdem/dem_postprocessing.py
+++ b/ragmac_xdem/dem_postprocessing.py
@@ -763,28 +763,28 @@ def merge_and_calculate_ddems(groups, validation_dates, ref_dem, mode, outdir, o
             
             ## Optimize chunking WIP
             
-            # option 1
-#             ds['band1'].data = ds['band1'].data.rechunk({0:-1, 1:'auto', 2:'auto'}, 
-#                                                         block_size_limit=1e8, 
-#                                                         balance=True)
-#             arr = ds['band1'].data
-#             t,y,x = arr.chunks[0][0], arr.chunks[1][0], arr.chunks[2][0]
-#             tasks_count = io.dask_get_mapped_tasks(ds['band1'].data)
-            
-            # option 2
-            mx, my, t = io.optimize_dask_chunks(ds)
-            x = mx
-            y = my
-            ds = ds.chunk({"time":t, "x":mx, "y":my})
+#             Option 1 - use built in method
+            ds['band1'].data = ds['band1'].data.rechunk({0:-1, 1:'auto', 2:'auto'}, 
+                                                        block_size_limit=1e8, 
+                                                        balance=True)
+            arr = ds['band1'].data
+            t,y,x = arr.chunks[0][0], arr.chunks[1][0], arr.chunks[2][0]
             tasks_count = io.dask_get_mapped_tasks(ds['band1'].data)
-            while tasks_count > 10000:
-                # increase chunk shape to reduce tasks
-                x += mx
-                y += my
-                # task_count increases if ds is not re-initialized
-                ds = io.xr_stack_geotifs(dems_list, dem_dates, ref_dem.filename)
-                ds = ds.chunk({"time":t, "x":x, "y":y})
-                tasks_count = io.dask_get_mapped_tasks(ds['band1'].data)
+            
+            # Option 2 - custom method finding balance between chunk shape, size, and task count
+#             mx, my, t = io.optimize_dask_chunks(ds)
+#             x = mx
+#             y = my
+#             ds = ds.chunk({"time":t, "x":mx, "y":my})
+#             tasks_count = io.dask_get_mapped_tasks(ds['band1'].data)
+#             while tasks_count > 10000:
+#                 # increase chunk shape to reduce tasks
+#                 x += mx
+#                 y += my
+#                 # task_count increases if ds is not re-initialized
+#                 ds = io.xr_stack_geotifs(dems_list, dem_dates, ref_dem.filename)
+#                 ds = ds.chunk({"time":t, "x":x, "y":y})
+#                 tasks_count = io.dask_get_mapped_tasks(ds['band1'].data)
             
             # see what we end up with
             print('chunk shape:', x,y,t)
@@ -792,9 +792,15 @@ def merge_and_calculate_ddems(groups, validation_dates, ref_dem, mode, outdir, o
             print('chunk size:',np.round(chunksize,2), 'MiB')
             print('tasks:', tasks_count)
             
+            from pathlib import Path
+            zarr_stack_fn = Path.joinpath(Path(dems_list[0]).parents[0],'stack.zarr')
+            if zarr_stack_fn.exists() and not overwrite:
+                ds.to_zarr(zarr_stack_fn)
+            ds = xr.open_dataset(zarr_stack_fn,
+                                            chunks={'time': t, 'y': y, 'x':x})
+            
             # TODO pass down client object to print address here instead of earlier.
-            
-            
+
             count_thresh = 5
             print('\nExcluding pixels with count <',count_thresh)
             

--- a/ragmac_xdem/io.py
+++ b/ragmac_xdem/io.py
@@ -15,14 +15,15 @@ import logging
 @author: friedrichknuth
 """
 
-def dask_start_cluster(nproc, threads=1, ip_addres=None):
+def dask_start_cluster(nproc, threads=1, ip_addres=None, port=':8786'):
     """
     Starts a dask cluster. Can provide a custom IP or URL to view the progress dashboard. 
     This may be necessary if working on a remote machine.
     """
     cluster = LocalCluster(n_workers=nproc,
-                       threads_per_worker=threads,
-                       silence_logs=logging.ERROR)
+                           threads_per_worker=threads,
+                           silence_logs=logging.ERROR,
+                           dashboard_address=port)
 
     client = Client(cluster)
     

--- a/ragmac_xdem/io.py
+++ b/ragmac_xdem/io.py
@@ -227,7 +227,7 @@ def xr_stack_geotifs(geotif_files_list,
 
         if save_to_nc:
             out_fn = str(pathlib.Path(file_name).with_suffix("")) + ".nc"
-            pathlib.Path(out_fn).unlink()
+            pathlib.Path(out_fn).unlink(missing_ok=True) #force delete file if exists
             src.to_netcdf(out_fn)
             out_dir = str(pathlib.Path(geotif_files_list[index]).parents[0])
             nc_files.append(out_fn)

--- a/ragmac_xdem/main.py
+++ b/ragmac_xdem/main.py
@@ -34,7 +34,7 @@ runs = {
 }
 
 
-def main(case: dict, mode: str, run_name: str, sat_type: str = "ASTER", nproc: int = None, overwrite: bool = False):
+def main(case: dict, mode: str, run_name: str, sat_type: str = "ASTER", nproc: int = None, overwrite: bool = False, qc: bool = False):
     """ 
     Run the processing for a given experiment case, processing mode and run.
 
@@ -44,6 +44,7 @@ def main(case: dict, mode: str, run_name: str, sat_type: str = "ASTER", nproc: i
     :param sat_type: the satellite data to be used, either 'ASTER', 'TDX' or 'both'
     :param nproc: number of processes to be run in parallel whenever possible (Default is max CPU - 1)
     :param overwrite: If set to True, will overwrite already processed data
+    :param qc: "If set, will produce quality control products
     """
     # Record time
     t1 = time()
@@ -146,50 +147,180 @@ def main(case: dict, mode: str, run_name: str, sat_type: str = "ASTER", nproc: i
         
         outfig = os.path.join(outdir, pair_id+"_coreg_fig.png")
         
-        if not os.path.exists(outfig):
+        if qc:
+            if not os.path.exists(outfig) or overwrite == True:
+                from pathlib import Path
+                import xarray as xr
+
+                print('\nCreating coregistration QC figures for period',pair_id)
+                
+                zarr_stack_fn = Path.joinpath(Path(dems_list[0]).parents[0],'stack.zarr')
+                
+                if zarr_stack_fn.exists() and not overwrite:
+                    print('Found existing zarr stack at')
+                    print(str(zarr_stack_fn))
+                    dems_ds = xr.open_dataset(zarr_stack_fn)
+                    dems_ds['band1'].data = dems_ds['band1'].data.rechunk({0:-1, 1:'auto', 2:'auto'}, 
+                                                                          block_size_limit=1e8, 
+                                                                          balance=True)
+                    arr = dems_ds['band1'].data
+                    t,y,x = arr.chunks[0][0], arr.chunks[1][0], arr.chunks[2][0]
+                    dems_ds = xr.open_dataset(zarr_stack_fn,
+                                              chunks={'time': t, 'y': y, 'x':x})
+                    
+                else:
+                    nc_files = list(Path(dems_list[0]).parents[0].glob('*.nc'))
+                    if len(nc_files) == len(dems_list):
+                        print('Found', len(nc_files), '.nc files for', len(dems_list), '.tif files')
+                        dems_ds = xr.open_mfdataset(nc_files, parallel=True)
+                    else:
+                        print('Stacking raw DEMs',pair_id)
+                        dems_ds = io.xr_stack_geotifs(dems_list,dem_dates,ref_dem.filename, save_to_nc=True)
+                        nc_files = list(Path(dems_list[0]).parents[0].glob('*.nc'))
+
+
+                    ## Optimize chunking 
+                    t = len(dems_ds.time)
+                    x = len(dems_ds.x)
+                    y = len(dems_ds.y)
+                    print('\ndata dims: x, y, time')
+                    print('data shape:',x,y,t)
+
+                    dems_ds['band1'].data = dems_ds['band1'].data.rechunk({0:-1, 1:'auto', 2:'auto'}, 
+                                                                          block_size_limit=1e8, 
+                                                                          balance=True)
+                    arr = dems_ds['band1'].data
+                    t,y,x = arr.chunks[0][0], arr.chunks[1][0], arr.chunks[2][0]
+                    tasks_count = io.dask_get_mapped_tasks(dems_ds['band1'].data)
+
+                    print('chunk shape:', x,y,t)
+                    chunksize = dems_ds['band1'][:t,:y,:x].nbytes / 1048576
+                    print('chunk size:',np.round(chunksize,2), 'MiB')
+                    print('tasks:', tasks_count)
+
+                    ## Save to zarr
+                    print('Saving zarr stack to')
+                    print(str(zarr_stack_fn))
+                    
+                    zarr_stack_tmp_fn = Path.joinpath(Path(dems_coreg_list[0]).parents[0],'stack_tmp.zarr')
+                    
+                    dems_ds = xr.open_mfdataset(nc_files,parallel=True)
+                    dems_ds = dems_ds.drop(['spatial_ref']) 
+                    dems_ds.to_zarr(zarr_stack_tmp_fn)
+                    dems_ds = xr.open_dataset(zarr_stack_tmp_fn,
+                                              chunks={'time': t, 'y': y, 'x':x})
+                    
+                    dems_ds['band1'].encoding = {'chunks': (t, y, x)}
+                    dems_ds.to_zarr(zarr_stack_fn)
+                    dems_ds = xr.open_dataset(zarr_stack_fn,
+                                              chunks={'time': t, 'y': y, 'x':x})
+                    zarr_stack_tmp_fn.rmtree(ignore_errors=True)
             
-            print('\nCreating coregistration QC figures for period',pair_id)
+#                     # cleanup the nc files
+#                     print('removing nc files')
+#                     for f in Path(dems_list[0]).parents[0].glob('*.nc'):
+#                         f.unlink(missing_ok=True)
+                
+                step0 = time() 
+                print(f"Took {(step0-start)/60:.2f} minutes")
 
-            block_size_limit = 1e8
-            balance = True
-            print('Stacking raw DEMs',pair_id)
-            dems_ds = io.xr_stack_geotifs(dems_list,dem_dates,ref_dem.filename, save_to_nc=True)
-            dems_ds['band1'].data = dems_ds['band1'].data.rechunk({0:-1, 1:'auto', 2:'auto'}, 
-                                                                  block_size_limit=block_size_limit, 
-                                                                  balance=balance)
-            step0 = time() 
-            print(f"Took {(step0-start)/60:.2f} minutes")
+                print('Computing NMAD for raw DEMs stack')
+                nmad_da_before = temporal.xr_dask_nmad(dems_ds)
+                step1 = time() 
+                print(f"Took {(step1-step0)/60:.2f} minutes")
 
-            print('Computing NMAD for raw DEMs stack')
-            nmad_da_before = temporal.xr_dask_nmad(dems_ds)
-            step1 = time() 
-            print(f"Took {(step1-step0)/60:.2f} minutes")
+                
+                
+                
+                print('Stacking coregistetered DEMs',pair_id)
+                zarr_stack_coreg_fn = Path.joinpath(Path(dems_coreg_list[0]).parents[0],'stack.zarr')
+                
+                if zarr_stack_coreg_fn.exists() and not overwrite:
+                    print('Found existing zarr stack at')
+                    print(str(zarr_stack_coreg_fn))
+                    dems_coreg_ds = xr.open_dataset(zarr_stack_coreg_fn)
+                    dems_coreg_ds['band1'].data = dems_coreg_ds['band1'].data.rechunk({0:-1, 1:'auto', 2:'auto'}, 
+                                                                          block_size_limit=1e8, 
+                                                                          balance=True)
+                    arr = dems_coreg_ds['band1'].data
+                    t,y,x = arr.chunks[0][0], arr.chunks[1][0], arr.chunks[2][0]
+                    dems_coreg_ds = xr.open_dataset(zarr_stack_coreg_fn,
+                                                    chunks={'time': t, 'y': y, 'x':x})
+                    
+                else:
+                    nc_files = list(Path(dems_coreg_list[0]).parents[0].glob('*.nc'))
+                    if len(nc_files) == len(dems_coreg_list):
+                        print('Found', len(nc_files), '.nc files for', len(dems_coreg_list), '.tif files')
+                        dems_ds = xr.open_mfdataset(nc_files, parallel=True)
+                    else:
+                        print('Stacking coreg DEMs',pair_id)
+                        dems_coreg_ds = io.xr_stack_geotifs(dems_coreg_list,dem_dates,ref_dem.filename, save_to_nc=True)
+                        nc_files = list(Path(dems_coreg_list[0]).parents[0].glob('*.nc'))
 
-            print('Stacking coregistetered DEMs',pair_id)
 
-            dems_coreg_ds = io.xr_stack_geotifs(dems_coreg_list,dem_coreg_dates,ref_dem.filename, save_to_nc=True)
-            dems_coreg_ds['band1'].data = dems_coreg_ds['band1'].data.rechunk({0:-1, 1:'auto', 2:'auto'}, 
-                                                                  block_size_limit=block_size_limit, 
-                                                                  balance=balance)
-            step2 = time() 
-            print(f"Took {(step2-step1)/60:.2f} minutes")
+                    ## Optimize chunking 
+                    t = len(dems_coreg_ds.time)
+                    x = len(dems_coreg_ds.x)
+                    y = len(dems_coreg_ds.y)
+                    print('\ndata dims: x, y, time')
+                    print('data shape:',x,y,t)
 
-            print('Computing count and NMAD for coregistetered DEMs stack')
+                    dems_coreg_ds['band1'].data = dems_coreg_ds['band1'].data.rechunk({0:-1, 1:'auto', 2:'auto'}, 
+                                                                          block_size_limit=1e8, 
+                                                                          balance=True)
+                    arr = dems_coreg_ds['band1'].data
+                    t,y,x = arr.chunks[0][0], arr.chunks[1][0], arr.chunks[2][0]
+                    tasks_count = io.dask_get_mapped_tasks(dems_coreg_ds['band1'].data)
 
-            count_da = temporal.xr_dask_count(dems_coreg_ds)
-            nmad_da_after = temporal.xr_dask_nmad(dems_coreg_ds)
+                    print('chunk shape:', x,y,t)
+                    chunksize = dems_coreg_ds['band1'][:t,:y,:x].nbytes / 1048576
+                    print('chunk size:',np.round(chunksize,2), 'MiB')
+                    print('tasks:', tasks_count)
 
-            step3 = time() 
-            print(f"Took {(step3-step2)/60:.2f} minutes")
+                    ## Save to zarr
+                    print('Saving zarr stack to')
+                    print(str(zarr_stack_coreg_fn))
+                    
+                    zarr_stack_coreg_tmp_fn = Path.joinpath(Path(dems_coreg_list[0]).parents[0],'stack_tmp.zarr')
+                    
+                    dems_coreg_ds = xr.open_mfdataset(nc_files,parallel=True)
+                    dems_coreg_ds = dems_coreg_ds.drop(['spatial_ref']) 
+                    dems_coreg_ds.to_zarr(zarr_stack_coreg_tmp_fn)
+                    dems_coreg_ds = xr.open_dataset(zarr_stack_coreg_tmp_fn,
+                                              chunks={'time': t, 'y': y, 'x':x})
+                    
+                    dems_coreg_ds['band1'].encoding = {'chunks': (t, y, x)}
+                    dems_coreg_ds.to_zarr(zarr_stack_coreg_fn)
+                    dems_coreg_ds = xr.open_dataset(zarr_stack_coreg_fn,
+                                              chunks={'time': t, 'y': y, 'x':x})
+                    zarr_stack_coreg_tmp_fn.rmtree(ignore_errors=True)
+                    
+                
+#                     # cleanup the nc files
+#                     print('removing nc files')
+#                     for f in Path(dems_coreg_list[0]).parents[0].glob('*.nc'):
+#                         f.unlink(missing_ok=True)
+                        
+                step2 = time() 
+                print(f"Took {(step2-step1)/60:.2f} minutes")
 
-            outfig = os.path.join(outdir, pair_id+"_coreg_fig.png")
-            print('--> Saving plot to ',outfig)
-            plotting.xr_plot_count_nmad_before_after_coreg(count_da,
-                                                           nmad_da_before, 
-                                                           nmad_da_after,
-                                                           outfig=outfig)
-        else:
-            print('--> Plot already exists at',outfig)
+                print('Computing count and NMAD for coregistetered DEMs stack')
+
+                count_da = temporal.xr_dask_count(dems_coreg_ds)
+                nmad_da_after = temporal.xr_dask_nmad(dems_coreg_ds)
+
+                step3 = time() 
+                print(f"Took {(step3-step2)/60:.2f} minutes")
+
+                outfig = os.path.join(outdir, pair_id+"_coreg_fig.png")
+                print('--> Saving plot to ',outfig)
+                plotting.xr_plot_count_nmad_before_after_coreg(count_da,
+                                                               nmad_da_before, 
+                                                               nmad_da_after,
+                                                               outfig=outfig)
+
+            else:
+                print('--> Plot already exists at',outfig)
 
     
 

--- a/scripts/main_experiment1.py
+++ b/scripts/main_experiment1.py
@@ -53,7 +53,9 @@ if __name__ == "__main__":
         default=mp.cpu_count() - 1,
         help="int, number of processes to be run in parallel whenever possible (Default is max CPU - 1)",
     )
-
+    parser.add_argument(
+        "-qc", dest="qc", action="store_true", help="If set, will produce quality control products"
+    )
     args = parser.parse_args()
 
     # List all possible cases, modes and runs to be processed
@@ -83,7 +85,7 @@ if __name__ == "__main__":
 
             print(f"\n\n##### Running case {case}, mode {mode} and run {run} #####\n\n")
             try:
-                main.main(case, mode, run, sat_type=args.sat_type, nproc=args.nproc, overwrite=args.overwrite)
+                main.main(case, mode, run, sat_type=args.sat_type, nproc=args.nproc, overwrite=args.overwrite, qc=args.qc)
             except:
                 print("ERROR -> skipping run")
                 traceback.print_exc()

--- a/scripts/main_experiment2.py
+++ b/scripts/main_experiment2.py
@@ -53,7 +53,9 @@ if __name__ == "__main__":
         default=mp.cpu_count() - 1,
         help="int, number of processes to be run in parallel whenever possible (Default is max CPU - 1)",
     )
-
+    parser.add_argument(
+        "-qc", dest="qc", action="store_true", help="If set, will produce quality control products"
+    )
     args = parser.parse_args()
 
     # List all possible cases, modes and runs to be processed
@@ -88,7 +90,7 @@ if __name__ == "__main__":
 
                 print(f"\n\n##### Running case {case}, mode {mode} and run {run} #####\n\n")
                 try:
-                    main.main(case, mode, run, sat_type=args.sat_type, nproc=args.nproc, overwrite=args.overwrite)
+                    main.main(case, mode, run, sat_type=args.sat_type, nproc=args.nproc, overwrite=args.overwrite, qc=args.qc)
                 except:
                     print("ERROR -> skipping run")
                     traceback.print_exc()

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ install_requires =
     pandas
     dask
     distributed
+    zarr
     # opencv  -> fails with pip error...
     geoutils
     xdem


### PR DESCRIPTION
This PR adds a new `-qc` flag to main processing scripts, which makes producing additional quality control products optional. 

Example:

```python scripts/main_experiment2.py -c RU_FJL -run CTL -mode TimeSeries2 -qc```

DEM stacks are now saved on disk before computation, chunked as `zarr` store with ~100 MiB chunk sizes and full time dimension in each chunk. This significantly improves io and task distribution during dask time series operations. 