### PR TITLE
Remove obsolete function and fix comment

### DIFF
--- a/ragmac_xdem/dem_postprocessing.py
+++ b/ragmac_xdem/dem_postprocessing.py
@@ -860,7 +860,7 @@ def merge_and_calculate_ddems(groups, validation_dates, ref_dem, mode, outdir, o
 #             min_date = np.percentile(ds.time, 2) # in case of outlier DEMs in time
 #             max_date = np.percentile(ds.time, 98)
 #             time_delta_max = int((max_date - min_date).astype('timedelta64[D]') / np.timedelta64(1, 'D'))
-#             time_delta_min = min(4*365, int(time_delta_max * 0.5))
+#             time_delta_min = max(4*365, int(time_delta_max * 0.5))
 #             print("Min 2 percentile date:",np.datetime_as_string(min_date, unit='D'))
 #             print("Max 98 percentile date:",np.datetime_as_string(max_date, unit='D'))
 #             print("Time delta between dates:",time_delta_max, 'days')


### PR DESCRIPTION
Removes custom `optimize_dask_chunks()` function, which is no longer used by the processing workflow. 

Instead we use the built in method, e.g.

`dask.array.Array.rechunk({0:-1, 1:'auto', 2:'auto'}, 
                                                        block_size_limit=1e8, 
                                                        balance=True)` where dim `0` is the time dimension.

Merging this PR has no impact on results.