### PR TITLE
Ensure that environment.yml works with future updates

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,8 @@ dependencies:
   - matplotlib
   - toml
   - pandas
-  - xdem
+  - xdem = 0.0.6
+  - geoutils = 0.0.8
   - rioxarray
   - opencv
   - oggm
@@ -20,6 +21,3 @@ dependencies:
   - pip
   # dev requirements
   - pytest
-  - pip:
-    - -e "git+https://github.com/GlacioHack/GeoUtils.git@main#egg=geoutils"
-    - -e "git+https://github.com/GlacioHack/xdem.git@main#egg=xdem"

--- a/environment.yml
+++ b/environment.yml
@@ -3,13 +3,16 @@ channels:
   - conda-forge
   - oggm
 dependencies:
-  - numpy
-  - scipy
+  - python = 3.9
+  - numpy = 1.21
+  - scipy = 1.7
   - matplotlib
-  - toml
-  - pandas
+  - toml = 0.10
+  - numba = 0.55
+  - pandas = 1.3
   - xdem = 0.0.6
   - geoutils = 0.0.8
+  - rasterio = 1.2.10
   - rioxarray
   - opencv
   - oggm


### PR DESCRIPTION
Make sure that the environment.yml allows running the code as it was used for the RAGMAC intercomparison (last change in June 2022): 
- Hard-code geoutils and xdem version, which have changed a lot
- hard-code rasterio version as it was causing an error
- hard-code numba version as it was raising a warning
- hard-code python, numpy, scipy, pandas and toml versions for safety.

Hopefully this will not be too restrictive for any type of architecture...

TODO:
- add a test to ensure that some outputs are well reproduced with the set environment.